### PR TITLE
Add openai env options; Add example script

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,40 @@
+from tree_of_thoughts import OpenAILanguageModel, CustomLanguageModel, TreeofThoughts, OptimizedOpenAILanguageModel, OptimizedTreeofThoughts
+
+use_v2 = False
+api_key=""
+api_base= "" # leave it blank if you simply use default openai api url
+
+if not use_v2:
+    #v1
+    model = OpenAILanguageModel(api_key, api_base=api_base)
+else:
+    #v2 parallel execution, caching, adaptive temperature
+    model = OptimizedOpenAILanguageModel(api_key, api_base=api_base)
+
+#choose search algorithm('BFS' or 'DFS')
+search_algorithm = "BFS"
+
+#cot or propose
+strategy="cot"
+
+# value or vote
+evaluation_strategy = "value"
+
+if not use_v2:
+    #create an instance of the tree of thoughts class v1
+    tree_of_thoughts = TreeofThoughts(model, search_algorithm)
+else:
+    #or v2 -> dynamic beam width -< adjust the beam width [b] dynamically based on the search depth quality of the generated thoughts
+    tree_of_thoughts= OptimizedTreeofThoughts(model, search_algorithm)
+
+input_problem = "What are next generation reasoning methods for Large Language Models"
+k = 5
+T = 3
+b = 5
+vth = 0.5
+
+#call the solve method with the input problem and other params
+solution = tree_of_thoughts.solve(input_problem, k, T, b, vth, )
+
+#use the solution in your production environment
+print(solution)

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from tree_of_thoughts import OpenAILanguageModel, CustomLanguageModel, TreeofThoughts, OptimizedOpenAILanguageModel, OptimizedTreeofThoughts
+from tree_of_thoughts.treeofthoughts import OpenAILanguageModel, CustomLanguageModel, TreeofThoughts, OptimizedOpenAILanguageModel, OptimizedTreeofThoughts
 
 use_v2 = False
 api_key=""
@@ -6,10 +6,10 @@ api_base= "" # leave it blank if you simply use default openai api url
 
 if not use_v2:
     #v1
-    model = OpenAILanguageModel(api_key, api_base=api_base)
+    model = OpenAILanguageModel(api_key=api_key, api_base=api_base)
 else:
     #v2 parallel execution, caching, adaptive temperature
-    model = OptimizedOpenAILanguageModel(api_key, api_base=api_base)
+    model = OptimizedOpenAILanguageModel(api_key=api_key, api_base=api_base)
 
 #choose search algorithm('BFS' or 'DFS')
 search_algorithm = "BFS"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
   ],
   install_requires=[
     'torch>=1.6'
+    'openai'
   ],
   classifiers=[
     'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     "Prompt Engineering"
   ],
   install_requires=[
-    'torch>=1.6'
+    'torch>=1.6',
     'openai'
   ],
   classifiers=[

--- a/tree_of_thoughts/treeofthoughts.py
+++ b/tree_of_thoughts/treeofthoughts.py
@@ -255,59 +255,61 @@ class OptimizedTreeofThoughts(TreeofThoughts):
         else:
             raise ValueError("Invalid search algorithm. Choose 'BFS' or 'DFS'.")
 
-search_algorithm = "DFS"
-strategy = "cot"
-evaluation_strategy="vote"
+if __name__ == '__main__':
 
-#create instance
-model = OptimizedOpenAILanguageModel('api-key')
+    search_algorithm = "DFS"
+    strategy = "cot"
+    evaluation_strategy="vote"
 
-
-tree_of_thoughts = OptimizedTreeofThoughts(model, search_algorithm)
-
-input_problem = "What is 3032 * 322 - 1"
-k = 5
-T = 3
-b = 5
-vth = 0.5
-timeout = 10
-
-# Optimal nominal values for the stopping conditions
-confidence = 0.9 #HIGH QUALITY SOLIUTION FOUND
-max_iterations = 5 # MAX ITERATIONS 10
-convergence_threshold = 0.01 #Convergence Check: Monitor the change in evaluation values between consecutive iterations. If the change in evaluation values is below a certain threshold for a specified number of consecutive iterations, the algorithm can stop and return the solution.
-convergence_count = 5
-
-#call the solve method with the input problem and other params
-solution = tree_of_thoughts.solve(input_problem, k, T, b, vth=vth, confidence_threshold=confidence, max_iterations=max_iterations, convergence_threshold=convergence_threshold, convergence_count=convergence_count)
-
-#use the solution in env
-print(f"solution: {solution}")
-
-"""
-should return something like this:
-
-['1. Utilizing reinforcement learning techniques to train large language models can be an effective approach to advancing them.\n2. Developing methods to better incorporate contextual information into large language models can help in their advancement.\n3. Incorpor', '1. Utilizing reinforcement learning techniques to allow for more efficient training of large language models.\n2. Incorporating transfer learning to leverage existing language models for faster and more accurate inference.\n3. Exploring the use of distributed', '1. Identifying and understanding key components of large language models such as natural language processing and machine learning algorithms.\n2. Utilizing methods such as transfer learning to quickly and efficiently train large language models.\n3. Incorporating', '1. Utilizing reinforcement learning techniques to train large language models can be an effective method of advancing them.\n2. Incorporating techniques such as transfer learning and data augmentation can help improve the performance of large language models.', '1. Identifying and understanding the underlying structure of language is essential to advancing large language models.\n2. Developing methods to effectively capture and represent the complexities of language is necessary for the advancement of large language models.\n3. Ut']
-0.8
-0.8
-['4. Analyzing and interpreting large language models to identify areas of improvement.\n5. Utilizing reinforcement learning to enable models to learn from mistakes and further improve accuracy.\n6. Leveraging automated data augmentation techniques to further improve', '4. Experimenting with different architectures and hyperparameters to determine the best model for a given task.\n5. Incorporating techniques such as data augmentation and ensembling to improve the performance of large language models.\n6', '4. Exploring methods to improve the efficiency of large language models such as using distributed computing techniques.\n5. Developing methods to reduce overfitting and improve generalization of large language models.\n6. Incorporating techniques such as', '4. Exploring and utilizing different types of data sets to train large language models.\n5. Developing strategies to optimize the training process and improve the performance of large language models.\n6. Applying advanced techniques such as deep learning', '4. Exploring methods such as reinforcement learning to improve the accuracy and robustness of large language models.\n5. Utilizing data augmentation techniques to increase the amount of training data available to the model.\n6. Incorpor']
-0.8
-0.8
-['7. Developing automated testing frameworks to validate the accuracy of large language models.\n8. Exploring ways to improve the scalability of large language models.\n9. Exploring ways to improve the efficiency of large language models.', '7. Applying methods such as active learning to further refine large language models.\n8. Developing and utilizing techniques such as knowledge distillation to compress large language models.\n9. Incorporating techniques such as semi-supervised', '7. Applying regularization techniques to reduce overfitting and improve generalization of large language models.\n8. Exploring the use of generative adversarial networks to improve the accuracy of large language models.\n9. Applying deep', '7. Developing methods to evaluate the performance of large language models on various tasks.\n8. Applying techniques such as hyperparameter tuning to optimize the performance of large language models.\n9. Utilizing adversarial training to', '7. Developing strategies to ensure large language models are able to generalize to unseen data.\n8. Incorporating methods such as meta-learning to further improve model performance.\n9. Utilizing techniques such as unsuper']
-0.7
-0.7
-['Once the key components of large language models have been identified and understood, the best reasoning methods to advance them include utilizing transfer learning to quickly train them, analyzing and interpreting them to identify areas of improvement, leveraging reinforcement learning to enable them to learn']
-0.7
-0.7
-['Exploring the use of meta-learning to enable models to rapidly adapt to new data and improve accuracy.']
-0.7
-0.7
-['One potential way to further advance large language models is to incorporate automated data augmentation techniques to create more varied datasets to train the models on, as well as leveraging reinforcement learning to enable the models to learn from mistakes and continually improve accuracy.']
-0.7
-0.7
-['By utilizing these methods, we can continue to advance large language models by improving their accuracy and performance. We can also use these methods to identify weaknesses in the models and make modifications to address them. Additionally, these methods can help us to develop']
-0.7
-0.7
+    #create instance
+    model = OptimizedOpenAILanguageModel('api-key')
 
 
-"""
+    tree_of_thoughts = OptimizedTreeofThoughts(model, search_algorithm)
+
+    input_problem = "What is 3032 * 322 - 1"
+    k = 5
+    T = 3
+    b = 5
+    vth = 0.5
+    timeout = 10
+
+    # Optimal nominal values for the stopping conditions
+    confidence = 0.9 #HIGH QUALITY SOLIUTION FOUND
+    max_iterations = 5 # MAX ITERATIONS 10
+    convergence_threshold = 0.01 #Convergence Check: Monitor the change in evaluation values between consecutive iterations. If the change in evaluation values is below a certain threshold for a specified number of consecutive iterations, the algorithm can stop and return the solution.
+    convergence_count = 5
+
+    #call the solve method with the input problem and other params
+    solution = tree_of_thoughts.solve(input_problem, k, T, b, vth=vth, confidence_threshold=confidence, max_iterations=max_iterations, convergence_threshold=convergence_threshold, convergence_count=convergence_count)
+
+    #use the solution in env
+    print(f"solution: {solution}")
+
+    """
+    should return something like this:
+
+    ['1. Utilizing reinforcement learning techniques to train large language models can be an effective approach to advancing them.\n2. Developing methods to better incorporate contextual information into large language models can help in their advancement.\n3. Incorpor', '1. Utilizing reinforcement learning techniques to allow for more efficient training of large language models.\n2. Incorporating transfer learning to leverage existing language models for faster and more accurate inference.\n3. Exploring the use of distributed', '1. Identifying and understanding key components of large language models such as natural language processing and machine learning algorithms.\n2. Utilizing methods such as transfer learning to quickly and efficiently train large language models.\n3. Incorporating', '1. Utilizing reinforcement learning techniques to train large language models can be an effective method of advancing them.\n2. Incorporating techniques such as transfer learning and data augmentation can help improve the performance of large language models.', '1. Identifying and understanding the underlying structure of language is essential to advancing large language models.\n2. Developing methods to effectively capture and represent the complexities of language is necessary for the advancement of large language models.\n3. Ut']
+    0.8
+    0.8
+    ['4. Analyzing and interpreting large language models to identify areas of improvement.\n5. Utilizing reinforcement learning to enable models to learn from mistakes and further improve accuracy.\n6. Leveraging automated data augmentation techniques to further improve', '4. Experimenting with different architectures and hyperparameters to determine the best model for a given task.\n5. Incorporating techniques such as data augmentation and ensembling to improve the performance of large language models.\n6', '4. Exploring methods to improve the efficiency of large language models such as using distributed computing techniques.\n5. Developing methods to reduce overfitting and improve generalization of large language models.\n6. Incorporating techniques such as', '4. Exploring and utilizing different types of data sets to train large language models.\n5. Developing strategies to optimize the training process and improve the performance of large language models.\n6. Applying advanced techniques such as deep learning', '4. Exploring methods such as reinforcement learning to improve the accuracy and robustness of large language models.\n5. Utilizing data augmentation techniques to increase the amount of training data available to the model.\n6. Incorpor']
+    0.8
+    0.8
+    ['7. Developing automated testing frameworks to validate the accuracy of large language models.\n8. Exploring ways to improve the scalability of large language models.\n9. Exploring ways to improve the efficiency of large language models.', '7. Applying methods such as active learning to further refine large language models.\n8. Developing and utilizing techniques such as knowledge distillation to compress large language models.\n9. Incorporating techniques such as semi-supervised', '7. Applying regularization techniques to reduce overfitting and improve generalization of large language models.\n8. Exploring the use of generative adversarial networks to improve the accuracy of large language models.\n9. Applying deep', '7. Developing methods to evaluate the performance of large language models on various tasks.\n8. Applying techniques such as hyperparameter tuning to optimize the performance of large language models.\n9. Utilizing adversarial training to', '7. Developing strategies to ensure large language models are able to generalize to unseen data.\n8. Incorporating methods such as meta-learning to further improve model performance.\n9. Utilizing techniques such as unsuper']
+    0.7
+    0.7
+    ['Once the key components of large language models have been identified and understood, the best reasoning methods to advance them include utilizing transfer learning to quickly train them, analyzing and interpreting them to identify areas of improvement, leveraging reinforcement learning to enable them to learn']
+    0.7
+    0.7
+    ['Exploring the use of meta-learning to enable models to rapidly adapt to new data and improve accuracy.']
+    0.7
+    0.7
+    ['One potential way to further advance large language models is to incorporate automated data augmentation techniques to create more varied datasets to train the models on, as well as leveraging reinforcement learning to enable the models to learn from mistakes and continually improve accuracy.']
+    0.7
+    0.7
+    ['By utilizing these methods, we can continue to advance large language models by improving their accuracy and performance. We can also use these methods to identify weaknesses in the models and make modifications to address them. Additionally, these methods can help us to develop']
+    0.7
+    0.7
+
+
+    """

--- a/tree_of_thoughts/treeofthoughts.py
+++ b/tree_of_thoughts/treeofthoughts.py
@@ -2,6 +2,7 @@ import concurrent.futures
 from abc import ABC, abstractmethod
 import openai
 import os
+import re
 import time
 
 class AbstractLanguageModel(ABC):
@@ -39,7 +40,7 @@ class OpenAILanguageModel(AbstractLanguageModel):
         if api_base != "":
             # e.g. https://api.openai.com/v1/ or your custom url
             openai.api_base = api_base
-            print(f'Using custom api_base {self.api_base}')
+            print(f'Using custom api_base {api_base}')
             
         if api_model == "" or api_model == None:
             api_model = os.environ.get("OPENAI_API_MODEL", "")
@@ -49,28 +50,79 @@ class OpenAILanguageModel(AbstractLanguageModel):
             self.api_model = "text-davinci-003"
         print(f'Using api_model {self.api_model}')
 
+        self.use_chat_api = 'gpt' in self.api_model
+
         # reference : https://www.promptingguide.ai/techniques/react
         self.ReAct_prompt = ''
         if enable_ReAct_prompting:
-            self.ReAct_prompt = "Write down your observations in format 'Observation : \\n xxxx \\n', then write down your thoughts in format 'Thoughts : \\n xxxx \\n'."
+            self.ReAct_prompt = "Write down your observations in format 'Observation:xxxx', then write down your thoughts in format 'Thoughts:xxxx'."
         
         self.strategy = strategy
         self.evaluation_strategy = evaluation_strategy
+
+    def openai_api_call_handler(self, prompt, max_tokens, temperature, k=1, stop=None):
+        if self.use_chat_api:
+            message = [
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ]
+            response = openai.ChatCompletion.create(
+                model=self.api_model,
+                messages=message,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        else:
+            response = openai.Completion.create(
+                engine=self.api_model,
+                prompt=prompt,
+                n=k,
+                max_tokens=max_tokens,
+                stop=stop,
+                temperature=temperature,
+            )
+        return response
+
+    def openai_choice2text_handler(self, choice):
+        if self.use_chat_api:
+            text = choice['message']['content']
+        else:
+            text = choice.text.strip()
+        return text
 
     def generate_thoughts(self, state, k):
         state_text = ' '.join(state)
         
         prompt = f"Given the current state of reasoning: '{state_text}', generate {k} coherent thoughts to continue the reasoning process:"
         prompt += self.ReAct_prompt
-        response = openai.Completion.create(
-            engine=self.api_model,
-            prompt=prompt,
-            n=k,
-            max_tokens=50,
-            stop=None,
-            temperature=0.5,
-        )
-        thoughts = [choice.text.strip() for choice in response.choices]
+        if self.use_chat_api:
+            new_prompt_success = False
+            """
+            # Try prompt and parse in a single shot to save tokens (but if we fail, we end up spending more tokens)
+            new_prompt = prompt + "Thought string should be output in a format that can be parsed into python array in format [xxx,xxx,xxx]"
+            response = self.openai_api_call_handler(new_prompt, 100 * k, 0.5, 1)
+            text = self.openai_choice2text_handler(response.choices[0])
+            re_parse = re.search(r'\[(.*?)\]', text)
+            if re_parse:
+                thoughts_str = re_parse.group(1)
+                if thoughts_str:
+                    thoughts = thoughts_str.split(',')
+                    new_prompt_success = len(thoughts) == k 
+                    if not new_prompt_success:
+                        print(f"Fall back to multi-prompt for chat-completion due to parse fail {text}")
+            """
+
+            if not new_prompt_success:
+                thoughts = []
+                for _ in range(k):
+                    response = self.openai_api_call_handler(prompt, 100, 0.5, 1)
+                    text = self.openai_choice2text_handler(response.choices[0])
+                    thoughts += [text]
+        else:
+            response = self.openai_api_call_handler(prompt, 50, 0.5, k)
+            thoughts = [self.openai_choice2text_handler(choice) for choice in response.choices]
         # print(thoughts)
         print(f"Generated thoughts: {thoughts}")
         return thoughts
@@ -81,18 +133,11 @@ class OpenAILanguageModel(AbstractLanguageModel):
             for state in states:
                 state_text = ' '.join(state)
                 prompt = f"Given the current state of reasoning: '{state_text}', evaluate its value as a float between 0 and 1, and NOTHING ELSE:"
-                response = openai.Completion.create(
-                    engine=self.api_model,
-                    prompt=prompt,
-                    n=1,
-                    max_tokens=10,
-                    stop=None,
-                    temperature=1,
-                )
+                response = self.openai_api_call_handler(prompt, 10, 1)
                 try:
-                    value_text = response.choices[0].text.strip()
+                    value_text = self.openai_choice2text_handler(response.choices[0])
                     print(f"Value text {value_text}")
-                    value = float(response.choices[0].text.strip())
+                    value = float(value_text)
                     print(f"value: {value}")
                 except ValueError:
                     value = 0  # Assign a default value if the conversion fails
@@ -102,15 +147,8 @@ class OpenAILanguageModel(AbstractLanguageModel):
         elif self.evaluation_strategy == 'vote':
             states_text = '\n'.join([' '.join(state) for state in states])
             prompt = f"Given the following states of reasoning, vote for the best state:\n{states_text}\n\nVote, and NOTHING ELSE:"
-            response = openai.Completion.create(
-                engine=self.api_model,
-                prompt=prompt,
-                n=1,
-                max_tokens=50,
-                stop=None,
-                temperature=1,
-            )
-            best_state_text = response.choices[0].text.strip()
+            response = self.openai_api_call_handler(prompt, 50, 1)
+            best_state_text = self.openai_choice2text_handler(response.choices[0])
             print(f"Best state text: {best_state_text}")
             best_state = tuple(best_state_text.split())
             return {state: 1 if state == best_state else 0 for state in states}


### PR DESCRIPTION
1, Allow users to quickly adjust API key, base url, model using env variables. For example, startup different instances using docker with different .env, etc
2, Add example script from readme to repo
3, Add ReAct prompts as an option
4, Add chat completion api/response support for gpt4/chagpt, and rate limiter exception handle as well